### PR TITLE
Slightly improved check for SPARQL update queries

### DIFF
--- a/src/SparqlClient.php
+++ b/src/SparqlClient.php
@@ -544,7 +544,7 @@ final class SparqlClient extends Base
             case "raw":
             default: // rows
                 $response = "";
-                if (preg_match("/(INSERT|DELETE|CLEAR|LOAD)/i", $q)) {
+                if (preg_match("/\s(INSERT|DELETE|CLEAR|LOAD)\s/i", $q)) {
                     $response = $this->queryUpdate($q);
                 } else {
                     $response = $this->queryRead($q);


### PR DESCRIPTION
It is not much but solves my problem at least. It would of course not handle queries like
`select * where { ?s rdfs:label ?l . filter(contains(str(?l), "LOAD")) . }`
