### PR TITLE
Fixes accept header not sent via GET request

### DIFF
--- a/src/Curl.php
+++ b/src/Curl.php
@@ -198,11 +198,12 @@ class Curl
      *
      * @param string $url
      * @param array $getData get data array ie. $foo['get_var_name'] = $value (default null)
+     * @param array $arrayHeader header array of the HTTP request (default null)
      * @param string $ip address to bind (default null)
      * @param int $timeout in sec for complete curl operation (default 600)
      * @return bool|string data
      */
-    public function fetchUrl($url, $getData = null, $ip = null, $timeout = 600)
+    public function fetchUrl($url, $getData = null, $arrayHeader = null, $ip = null, $timeout = 600)
     {
         if ($this->_debug) {
             curl_setopt($this->_curlHandler, CURLOPT_VERBOSE, true);
@@ -223,6 +224,10 @@ class Curl
         } else {
             $get_string = null;
         }
+
+        // set header
+        if ($arrayHeader != null)
+            curl_setopt($this->_curlHandler, CURLOPT_HTTPHEADER, $arrayHeader);
 
         // set url to post to
         if (empty($get_string)) {

--- a/src/SparqlClient.php
+++ b/src/SparqlClient.php
@@ -637,13 +637,13 @@ final class SparqlClient extends Base
                 $response = $client->sendPostData($sUri, $data,null, null, $timeout);
             } else {
                 //TODO PHP8.0 use named arguments
-                $response = $client->fetchUrl($sUri, $data, null, $timeout); // fix for wikidata
+                $response = $client->fetchUrl($sUri, $data, null, null, $timeout); // fix for wikidata
             }
         } else {
             $data = array(
                 $this->_nameParameterQueryRead => $query,
                 "output" => Mimetype::getShortNameOfMimetype($typeOutput), // possible fix for 4store/fuseki..
-                "Accept" => $typeOutput
+                "format" => Mimetype::getShortNameOfMimetype($typeOutput) // some endpoints use 'format' param
             ); // fix for sesame
                                       // print_r($data);
             if ($this->_methodHTTPRead == "POST") {
@@ -653,7 +653,9 @@ final class SparqlClient extends Base
                 ),null, $timeout);
             } else {
                 //TODO PHP8.0 use named arguments
-                $response = $client->fetchUrl($sUri, $data,null, $timeout); // fix for wikidata
+                $response = $client->fetchUrl($sUri, $data, array(
+                    'Accept: ' . $typeOutput
+                ), null, $timeout); // fix for wikidata
             }
         }
 
@@ -720,7 +722,7 @@ final class SparqlClient extends Base
                 $response = $client->sendPostData($sUri, $data, null, null, $timeout);
             } else {
                 //TODO PHP8.0 use named arguments
-                $response = $client->fetchUrl($sUri, $data,null, $timeout); // fix for wikidata
+                $response = $client->fetchUrl($sUri, $data, null, null, $timeout); // fix for wikidata
             }
         } else {
             $data = array(
@@ -737,7 +739,7 @@ final class SparqlClient extends Base
                 ), null, $timeout);
             } else {
                 //TODO PHP8.0 use named arguments
-                $response = $client->fetchUrl($sUri, $data, null, $timeout); // fix for wikidata
+                $response = $client->fetchUrl($sUri, $data, null,  null, $timeout); // fix for wikidata
             }
         }
 


### PR DESCRIPTION
* `Accept` header for the GET curl request was sent as an `Accept` URL parameter rather than a header, fixed by adding `$arrayHeader` param to the `fetchUrl` method of the `Curl` class
* Adds `format` URL parameter to GET requests to support AWS Neptune